### PR TITLE
Wire v2 profile schema into backend FastAPI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import ValidationError
+from pathlib import Path
+
+from models.profile_v2 import LearnerProfile
+
+app = FastAPI()
+
+PROFILE_PATH = Path("data/profile.json")
+
+@app.post("/next-session")
+async def next_session():
+    """Return the next learning session based on the v2 learner profile."""
+    try:
+        profile = LearnerProfile.parse_file(PROFILE_PATH)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Profile file not found")
+    except ValidationError:
+        raise HTTPException(
+            status_code=400,
+            detail="Legacy profile no longer supported—run migration."
+        )
+    # For now simply echo the learner id; real logic omitted
+    return {"learner_id": profile.learner_id}


### PR DESCRIPTION
## Summary
- create `backend/main.py` as a minimal FastAPI app
- load profile JSON using `LearnerProfile.parse_file`
- raise HTTP 400 if an old/invalid profile is used
- expose `/next-session` endpoint that reads the v2 profile

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ef40c729083209f311b058e406d32