### PR TITLE
Add badges util and end session endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,11 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from typing import Dict
+
 from models.profile_v2 import LearnerProfile
 from services.session_builder import build_session
+from services.badges import evaluate_badges
 
 app = FastAPI()
 
@@ -12,7 +15,20 @@ class SessionPayload(BaseModel):
     profile: LearnerProfile
 
 
+class EndPayload(BaseModel):
+    """Payload for ending a session and reporting metrics."""
+    profile: LearnerProfile
+    session_metrics: Dict[str, int]
+
+
 @app.post("/next-session")
 async def next_session(payload: SessionPayload):
     """Return the next learning session based on the v2 learner profile."""
     return build_session(payload.profile)
+
+
+@app.post("/api/end-session")
+async def end_session(payload: EndPayload):
+    """Finalize a session and evaluate badges earned."""
+    earned = evaluate_badges(payload.profile, payload.session_metrics)
+    return {"earned_badges": earned, "profile": payload.profile}

--- a/backend/services/badges.py
+++ b/backend/services/badges.py
@@ -1,0 +1,38 @@
+from typing import Dict, List
+
+from models.profile_v2 import LearnerProfile
+
+
+def evaluate_badges(profile: LearnerProfile, session_metrics: Dict) -> List[str]:
+    """Append new badges to profile.history.badges based on session metrics."""
+    earned: List[str] = []
+
+    history = profile.history
+
+    # Update overall session count
+    history.sessions_completed += 1
+
+    # Track progress counters stored on the history object
+    history.bookworm_progress = getattr(history, "bookworm_progress", 0)
+    history.puzzle_progress = getattr(history, "puzzle_progress", 0)
+
+    comprehension = session_metrics.get("comprehension", 0)
+    if comprehension >= 70:
+        history.bookworm_progress += 1
+        if history.bookworm_progress % 5 == 0:
+            history.badges.append("Bookworm Lv1")
+            earned.append("Bookworm Lv1")
+
+    problem_score = session_metrics.get("problem_solving_score", 0)
+    if problem_score >= 80:
+        history.puzzle_progress += 1
+        if history.puzzle_progress % 3 == 0:
+            history.badges.append("Puzzle Solver")
+            earned.append("Puzzle Solver")
+
+    keys_pct = session_metrics.get("keys_mastered_pct", 0)
+    if keys_pct >= 30 and "Home-Row Hero" not in history.badges:
+        history.badges.append("Home-Row Hero")
+        earned.append("Home-Row Hero")
+
+    return earned


### PR DESCRIPTION
## Summary
- add services/badges module for badge evaluation
- update backend API to expose `/api/end-session`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eff50dfac8320a225041d61637a4a