### PR TITLE
Add TypingHomeRow component

### DIFF
--- a/frontend/src/components/TypingHomeRow.jsx
+++ b/frontend/src/components/TypingHomeRow.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import sample from '../utils/sampleHomeRowText';
+
+export default function TypingHomeRow({ onFinish }) {
+  const [text] = useState(sample());
+  const [input, setInput] = useState('');
+  const correct = text.slice(0, input.length) === input;
+  const complete = input === text;
+
+  return (
+    <div>
+      <p className="font-mono bg-gray-100 p-2 rounded">{text}</p>
+      <input
+        className="w-full p-2 border"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        autoFocus
+      />
+      {complete && onFinish(correct)}
+    </div>
+  );
+}

--- a/frontend/src/utils/sampleHomeRowText.js
+++ b/frontend/src/utils/sampleHomeRowText.js
@@ -1,0 +1,14 @@
+const words = [
+  'a', 'as', 'sad', 'dash', 'add', 'fall', 'hall', 'had',
+  'has', 'all', 'glad', 'ask', 'salad', 'skill', 'jail',
+  'kid', 'fish', 'jig', 'lid', 'half'
+];
+
+export default function sampleHomeRowText() {
+  const count = 5 + Math.floor(Math.random() * 5);
+  const chosen = Array.from({ length: count }, () => {
+    const i = Math.floor(Math.random() * words.length);
+    return words[i];
+  });
+  return chosen.join(' ');
+}


### PR DESCRIPTION
## Summary
- introduce `TypingHomeRow` component for simple typing practice
- add `sampleHomeRowText` helper for a-l key sentences

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f01ed81888320a773c4d85feee981