### PR TITLE
Hook SessionTimer and TypingHomeRow into App

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,16 +1,38 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import axios from 'axios';
 
 import AudioRecorder from './AudioRecorder';
 import WebcamSnap from './WebcamSnap';
 import ActivityBox from './ActivityBox';
+import SessionTimer from './components/SessionTimer';
+import TypingHomeRow from './components/TypingHomeRow';
+import ComicPad from './components/ComicPad';
+
+const profile = { attention: { session_max_minutes: 30 } };
 
 export default function App() {
   const [threadId, setThreadId] = useState(null);
   const [activity, setActivity] = useState(null);
   const [moodScore, setMoodScore] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [showComic, setShowComic] = useState(false);
   const readAloudText = activity?.read_aloud || "";
+
+  useEffect(() => {
+    const openComic = () => setShowComic(true);
+    window.addEventListener('comic-break', openComic);
+    return () => window.removeEventListener('comic-break', openComic);
+  }, []);
+
+  const handleTypingDone = (correct) => {
+    console.log('typing complete', correct);
+  };
+
+  const endSession = () => {
+    setThreadId(null);
+    setActivity(null);
+    setMoodScore(null);
+  };
 
 
   // 1️⃣ Start a session and fetch the first activity
@@ -54,6 +76,7 @@ export default function App() {
           🚀 Start Karl’s Adventure
         </button>
       ) : (
+        <SessionTimer maxMinutes={profile.attention.session_max_minutes} onHardCap={endSession}>
         <>
           <div className="mb-4">
             <AudioRecorder
@@ -82,8 +105,11 @@ export default function App() {
 
           {/* Show the current activity */}
           <ActivityBox data={activity} />
+          <TypingHomeRow onFinish={handleTypingDone} />
         </>
+        </SessionTimer>
       )}
+      <ComicPad open={showComic} onClose={() => setShowComic(false)} />
     </main>
   );
 }

--- a/frontend/src/components/ComicPad.jsx
+++ b/frontend/src/components/ComicPad.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ComicPad({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-4 rounded shadow max-w-lg w-full">
+        <h2 className="text-xl font-bold mb-2">Comic Break!</h2>
+        <p className="mb-4">Enjoy a quick comic scene.</p>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wire up SessionTimer and TypingHomeRow in `App.jsx`
- show a ComicPad modal when `comic-break` fires

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f0336818c8320a1ec47ec0961e20f