### PR TITLE
Add smoke test for session API

### DIFF
--- a/backend/data/profile.json
+++ b/backend/data/profile.json
@@ -1,0 +1,15 @@
+{
+  "learner_id": "test_learner",
+  "demographics": {"age": 9, "grade": 4, "school_type": "public"},
+  "preferences": {
+    "modalities": ["video", "reading"],
+    "themes": ["space"],
+    "team_style": "solo",
+    "reward_mode": "badges"
+  },
+  "attention": {"focus_minutes": 15, "session_max_minutes": 30, "reset_strategy": "short_break"},
+  "reading": {"current_level": "4th", "avg_wpm": 100, "vocab_mastered": 20, "comprehension_score": 80},
+  "math": {"problem_solving_score": 80, "fact_memorization_opt_out": false},
+  "typing": {"keys_mastered_pct": 50, "current_wpm": 25},
+  "history": {"sessions_completed": 0, "badges": []}
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,9 +3,9 @@ from pydantic import BaseModel
 
 from typing import Dict
 
-from models.profile_v2 import LearnerProfile
-from services.session_builder import build_session
-from services.badges import evaluate_badges
+from .models.profile_v2 import LearnerProfile
+from .services.session_builder import build_session
+from .services.badges import evaluate_badges
 
 app = FastAPI()
 

--- a/backend/models/profile_v2.py
+++ b/backend/models/profile_v2.py
@@ -44,7 +44,7 @@ class History(BaseModel):
 
 
 class LearnerProfile(BaseModel):
-    learner_id: str = Field(..., regex=r"^[a-z0-9_]+$")
+    learner_id: str = Field(..., pattern=r"^[a-z0-9_]+$")
     demographics: Demographics
     preferences: Preferences
     attention: Attention

--- a/backend/services/badges.py
+++ b/backend/services/badges.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from models.profile_v2 import LearnerProfile
+from ..models.profile_v2 import LearnerProfile
 
 
 def evaluate_badges(profile: LearnerProfile, session_metrics: Dict) -> List[str]:

--- a/backend/services/session_builder.py
+++ b/backend/services/session_builder.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from models.profile_v2 import LearnerProfile
+from ..models.profile_v2 import LearnerProfile
 from typing import Dict
 import random
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import json, pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from backend.main import app
+
+client = TestClient(app)
+profile = json.load(open(pathlib.Path(__file__).parent/'../backend/data/profile.json'))
+
+
+def test_next_session():
+    resp = client.post('/next-session', json={"profile": profile, "recent_metrics": {}})
+    assert resp.status_code == 200
+    for key in ["intro","reading_text","math_quest","typing_text","comic_prompt"]:
+        assert key in resp.json()


### PR DESCRIPTION
## Summary
- fix backend imports to use package-relative paths
- update pydantic field arg to `pattern`
- add sample profile fixture for tests
- create session endpoint smoke test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f054931a88320bfe32ba0c821d535