### PR TITLE
Fix port in start_dev script

### DIFF
--- a/start_dev.bat
+++ b/start_dev.bat
@@ -22,4 +22,5 @@ start "Karl-Frontend" cmd /k ^
 
 REM ——— Auto-open browser after 3 s ———
 timeout /t 3 >nul
-start "" http://localhost:3000
+REM  Vite uses port 5173 for the dev server
+start "" http://localhost:5173


### PR DESCRIPTION
## Summary
- fix dev launcher to open correct Vite port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f13312f1c83209e825a1a7f35de36