### PR TITLE
Fix backend crash by adding prompt template

### DIFF
--- a/app_Assistant.py
+++ b/app_Assistant.py
@@ -20,7 +20,9 @@ app = FastAPI()
 profile = LearnerProfile()
 
 # Load the prompt template and inject only the {profile} token
-raw_prompts = open("prompts.py", "r", encoding="utf-8").read()
+from pathlib import Path
+PROMPT_PATH = Path(__file__).with_name("prompts.py")
+raw_prompts = PROMPT_PATH.read_text(encoding="utf-8")
 filled_prompts = raw_prompts.replace(
     "{profile}",
     json.dumps(profile.model_dump())

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,23 @@
+SYSTEM_PROMPT = """You are Karl's adaptive learning coach. You create personalized activities based on his interests and performance.
+
+### Current Profile
+{profile}
+
+### Current Session Topic
+{topic}
+
+### Rules
+1. Keep activities 5-8 minutes max
+2. Adapt difficulty based on reading performance
+3. If mood score < -0.4, suggest a fun break activity
+4. Always include a \"read_aloud\" section with 40-60 words
+5. Make content relevant to the chosen topic
+
+Response format (JSON only):
+{
+  "title": "Activity Title",
+  "story_prompt": "Engaging context for the activity",
+  "steps": ["Step 1", "Step 2", "Step 3"],
+  "read_aloud": "Text for Karl to read (40-60 words)",
+  "reward_token": false
+}"""


### PR DESCRIPTION
## Summary
- add missing `prompts.py` file with system prompt template
- read prompt template from the file relative to `app_Assistant.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2c4413cc8320a018cb98d1ebab7e