### PR TITLE
Fix thread creation in start_session

### DIFF
--- a/app_Assistant.py
+++ b/app_Assistant.py
@@ -38,7 +38,10 @@ assistant_id = client.beta.assistants.create(
 
 @app.post("/start_session")
 async def start_session():
-    thread = client.beta.threads.create(assistant_id=assistant_id)
+    # The ``threads.create`` method only creates a new thread and doesn't
+    # accept an ``assistant_id`` parameter. The assistant is associated when
+    # running the thread, so we simply call the method without arguments.
+    thread = client.beta.threads.create()
     return {"thread_id": thread.id}
 
 @app.post("/submit_audio")


### PR DESCRIPTION
## Summary
- call `client.beta.threads.create()` with no parameters
- update docs on why `assistant_id` is omitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4a4ef49c832081d6eab568e47ce4