### PR TITLE
Fix IndexError when next_activity has no messages

### DIFF
--- a/app_Assistant.py
+++ b/app_Assistant.py
@@ -101,6 +101,14 @@ async def next_activity(thread_id: str):
 
     # Grab the latest message
     messages = client.beta.threads.messages.list(thread_id=thread_id).data
-    reply = messages[-1].content
+    if not messages:
+        return {"activity": "No activity generated yet."}
+
+    latest = messages[0]
+    content_parts = latest.content or []
+    if content_parts and hasattr(content_parts[0], "text"):
+        reply = content_parts[0].text.value
+    else:
+        reply = str(content_parts)
 
     return {"activity": reply}


### PR DESCRIPTION
## Summary
- check for empty assistant messages list in `next_activity`
- extract text safely from OpenAI message content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685228d961fc83209439b093eb5a797c