### PR TITLE
Add playful hero UI with menu

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600&display=swap" rel="stylesheet">
     <title>Vite + React</title>
   </head>
   <body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,13 @@
   "dependencies": {
     "axios": "^1.9.0",
     "extendable-media-recorder": "^9.2.26",
+    "class-variance-authority": "^0.7.0",
+    "tailwind-merge": "^2.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-webcam": "^7.2.0"
+    "react-webcam": "^7.2.0",
+    "lucide-react": "^0.322.1",
+    "framer-motion": "^10.18.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,116 +1,14 @@
-import { useState, useEffect } from 'react';
-import axios from 'axios';
-
-import AudioRecorder from './AudioRecorder';
-import WebcamSnap from './WebcamSnap';
-import ActivityBox from './ActivityBox';
-import SessionTimer from './components/SessionTimer';
-import TypingHomeRow from './components/TypingHomeRow';
-import ComicPad from './components/ComicPad';
-
-const profile = { attention: { session_max_minutes: 30 } };
+import { useState } from "react";
+import Home from "./pages/Home";
+import Menu from "./pages/Menu";
+import StoryMode from "./pages/StoryMode";
 
 export default function App() {
-  const [threadId, setThreadId] = useState(null);
-  const [activity, setActivity] = useState(null);
-  const [moodScore, setMoodScore] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [showComic, setShowComic] = useState(false);
-  const readAloudText = activity?.read_aloud || "";
+  const [stage, setStage] = useState("home");
 
-  useEffect(() => {
-    const openComic = () => setShowComic(true);
-    window.addEventListener('comic-break', openComic);
-    return () => window.removeEventListener('comic-break', openComic);
-  }, []);
+  if (stage === "home") return <Home onStart={() => setStage("menu")} />;
+  if (stage === "menu") return <Menu onSelect={(mode) => setStage(mode)} />;
+  if (stage === "story") return <StoryMode />;
 
-  const handleTypingDone = (correct) => {
-    console.log('typing complete', correct);
-  };
-
-  const endSession = () => {
-    setThreadId(null);
-    setActivity(null);
-    setMoodScore(null);
-  };
-
-
-  // 1️⃣ Start a session and fetch the first activity
-  const newSession = async () => {
-    try {
-      setLoading(true);
-      const { data } = await axios.post('/api/start_session');
-      setThreadId(data.thread_id);
-
-      const actRes = await axios.get('/api/next_activity', {
-        params: { thread_id: data.thread_id }
-      });
-      setActivity(JSON.parse(actRes.data.activity));
-    } catch (e) {
-      console.error("Error starting session:", e);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // 2️⃣ Fetch the next activity (used after audio or by button)
-  const fetchActivity = async () => {
-    if (!threadId) return;
-    try {
-      setLoading(true);
-      const { data } = await axios.get('/api/next_activity', {
-        params: { thread_id: threadId }
-      });
-      setActivity(JSON.parse(data.activity));
-    } catch (e) {
-      console.error("Error fetching activity:", e);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <main className="p-6">
-
-      {!threadId ? (
-        <button onClick={newSession} disabled={loading}>
-          🚀 Start Karl’s Adventure
-        </button>
-      ) : (
-        <SessionTimer maxMinutes={profile.attention.session_max_minutes} onHardCap={endSession}>
-        <>
-          <div className="mb-4">
-            <AudioRecorder
-              threadId={threadId}
-              passageText={readAloudText}
-              afterSubmit={fetchActivity}
-            />
-            <WebcamSnap
-              threadId={threadId}
-              onMood={setMoodScore}
-            />
-          </div>
-
-          {/* Show mood score if we have one */}
-          {moodScore !== null && (
-            <p className="mb-4">🧠 Mood score: {moodScore}</p>
-          )}
-
-          <button
-            className="mb-4"
-            onClick={fetchActivity}
-            disabled={loading}
-          >
-            ⏭️ Next Task
-          </button>
-
-          {/* Show the current activity */}
-          <ActivityBox data={activity} />
-          <TypingHomeRow onFinish={handleTypingDone} />
-        </>
-        </SessionTimer>
-      )}
-      <ComicPad open={showComic} onClose={() => setShowComic(false)} />
-    </main>
-  );
+  return null;
 }

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,26 @@
+import { cva } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-xl font-display shadow-sm transition",
+  {
+    variants: {
+      variant: {
+        default: "bg-sky-500 text-white hover:bg-sky-600",
+        menu: "bg-amber-400 text-comicInk hover:bg-amber-500",
+      },
+      size: {
+        sm: "h-8 px-3 text-sm",
+        lg: "h-14 px-8 text-xl",
+        xl: "h-24 px-10 text-4xl",
+      },
+    },
+    defaultVariants: { variant: "default", size: "lg" },
+  }
+);
+
+export function Button({ className, variant, size, ...props }) {
+  return (
+    <button className={twMerge(buttonVariants({ variant, size }), className)} {...props} />
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,23 @@
+import { Button } from "../components/ui/button";
+import { motion } from "framer-motion";
+
+export default function Home({ onStart }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-sky-100 via-blue-100 to-grass-100">
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: "spring", stiffness: 400, damping: 20 }}
+      >
+        <Button
+          variant="menu"
+          size="xl"
+          onClick={onStart}
+          className="rounded-2xl shadow-2xl hover:scale-105 active:scale-95 focus-visible:outline-dashed focus-visible:outline-4 focus-visible:outline-amber-500"
+        >
+          Start Karl’s Adventure!
+        </Button>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -1,0 +1,23 @@
+import { Button } from "../components/ui/button";
+import { BookOpen, Gamepad2, Image as ImageIcon } from "lucide-react";
+
+export default function Menu({ onSelect }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100">
+      <Button variant="menu" size="lg" onClick={() => onSelect("story")}
+        className="hover:scale-105 active:scale-95">
+        <BookOpen className="mr-3 h-8 w-8" /> Story Mode
+      </Button>
+
+      <Button variant="menu" size="lg" onClick={() => onSelect("game")}
+        className="hover:scale-105 active:scale-95">
+        <Gamepad2 className="mr-3 h-8 w-8" /> Typing Challenge
+      </Button>
+
+      <Button variant="menu" size="lg" onClick={() => onSelect("draw")}
+        className="hover:scale-105 active:scale-95">
+        <ImageIcon className="mr-3 h-8 w-8" /> Comic Pad
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+import AudioRecorder from '../AudioRecorder';
+import WebcamSnap from '../WebcamSnap';
+import ActivityBox from '../ActivityBox';
+import SessionTimer from '../components/SessionTimer';
+import TypingHomeRow from '../components/TypingHomeRow';
+import ComicPad from '../components/ComicPad';
+
+const profile = { attention: { session_max_minutes: 30 } };
+
+export default function StoryMode() {
+  const [threadId, setThreadId] = useState(null);
+  const [activity, setActivity] = useState(null);
+  const [moodScore, setMoodScore] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [showComic, setShowComic] = useState(false);
+  const readAloudText = activity?.read_aloud || "";
+
+  useEffect(() => {
+    const openComic = () => setShowComic(true);
+    window.addEventListener('comic-break', openComic);
+    return () => window.removeEventListener('comic-break', openComic);
+  }, []);
+
+  const handleTypingDone = (correct) => {
+    console.log('typing complete', correct);
+  };
+
+  const endSession = () => {
+    setThreadId(null);
+    setActivity(null);
+    setMoodScore(null);
+  };
+
+
+  // 1️⃣ Start a session and fetch the first activity
+  const newSession = async () => {
+    try {
+      setLoading(true);
+      const { data } = await axios.post('/api/start_session');
+      setThreadId(data.thread_id);
+
+      const actRes = await axios.get('/api/next_activity', {
+        params: { thread_id: data.thread_id }
+      });
+      setActivity(JSON.parse(actRes.data.activity));
+    } catch (e) {
+      console.error("Error starting session:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 2️⃣ Fetch the next activity (used after audio or by button)
+  const fetchActivity = async () => {
+    if (!threadId) return;
+    try {
+      setLoading(true);
+      const { data } = await axios.get('/api/next_activity', {
+        params: { thread_id: threadId }
+      });
+      setActivity(JSON.parse(data.activity));
+    } catch (e) {
+      console.error("Error fetching activity:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6">
+
+      {!threadId ? (
+        <button onClick={newSession} disabled={loading}>
+          🚀 Start Karl’s Adventure
+        </button>
+      ) : (
+        <SessionTimer maxMinutes={profile.attention.session_max_minutes} onHardCap={endSession}>
+        <>
+          <div className="mb-4">
+            <AudioRecorder
+              threadId={threadId}
+              passageText={readAloudText}
+              afterSubmit={fetchActivity}
+            />
+            <WebcamSnap
+              threadId={threadId}
+              onMood={setMoodScore}
+            />
+          </div>
+
+          {/* Show mood score if we have one */}
+          {moodScore !== null && (
+            <p className="mb-4">🧠 Mood score: {moodScore}</p>
+          )}
+
+          <button
+            className="mb-4"
+            onClick={fetchActivity}
+            disabled={loading}
+          >
+            ⏭️ Next Task
+          </button>
+
+          {/* Show the current activity */}
+          <ActivityBox data={activity} />
+          <TypingHomeRow onFinish={handleTypingDone} />
+        </>
+        </SessionTimer>
+      )}
+      <ComicPad open={showComic} onClose={() => setShowComic(false)} />
+    </main>
+  );
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -4,16 +4,15 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        penguin: "#00A7E1",
-        polar: "#F0F9FF",
         comicInk: "#1B1B1B",
+        sky: { 500: "#38BDF8", 600: "#0EA5E9" },
+        amber: { 400: "#FBBF24", 500: "#F59E0B" },
+        grass: { 400: "#34D399", 500: "#10B981" },
       },
       fontFamily: {
         display: ["'Fredoka', sans-serif"],
       },
-      borderRadius: {
-        "2xl": "1.25rem",
-      },
+      borderRadius: { xl: "1rem", "2xl": "1.5rem" },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add custom button component with new variants
- extend Tailwind palette and fonts
- insert Fredoka font link in index.html
- implement Home and Menu pages styled with new buttons
- move old session flow to `StoryMode` page
- refactor `App.jsx` to stage between screens

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685243e155848320bee9956217ce2799