### PR TITLE
Fix export for TypingHomeRow

### DIFF
--- a/frontend/src/components/TypingHomeRow.jsx
+++ b/frontend/src/components/TypingHomeRow.jsx
@@ -5,7 +5,7 @@ import { Keyboard, CheckCircle, XCircle, RotateCcw, Clock, AlertCircle } from 'l
 import { Button } from './ui/button';
 import sample from '../utils/sampleHomeRowText';
 
-export function TypingHomeRow({ onFinish }) {
+export default function TypingHomeRow({ onFinish }) {
   const [text] = useState(sample());
   const [input, setInput] = useState('');
   const [isComplete, setIsComplete] = useState(false);
@@ -341,3 +341,4 @@ export function SessionTimer({ maxMinutes, children, onHardCap }) {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- export `TypingHomeRow` as the default export so StoryMode imports work

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685387ee1404832089b42d16e715adeb