### PR TITLE
Fix session timer and activity parsing

### DIFF
--- a/frontend/src/components/SessionTimer.jsx
+++ b/frontend/src/components/SessionTimer.jsx
@@ -13,7 +13,9 @@ export default function SessionTimer({ maxMinutes, children, onHardCap }) {
   return (
     <div>
       <div className="text-xs text-gray-500">⏱ {elapsed}/{maxMinutes} min</div>
-      {children}
+      {typeof children === "function"
+        ? children({ elapsed, maxMinutes })
+        : children}
     </div>
   );
 }

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -61,7 +61,12 @@ export default function StoryMode({ onBack }) {
       const actRes = await axios.get('/api/next_activity', {
         params: { thread_id: data.thread_id }
       });
-      setActivity(JSON.parse(actRes.data.activity));
+      try {
+        setActivity(JSON.parse(actRes.data.activity));
+      } catch (err) {
+        console.error('Failed to parse activity:', err);
+        setActivity(null);
+      }
     } catch (e) {
       console.error("Error starting session:", e);
     } finally {
@@ -77,7 +82,12 @@ export default function StoryMode({ onBack }) {
       const { data } = await axios.get('/api/next_activity', {
         params: { thread_id: threadId }
       });
-      setActivity(JSON.parse(data.activity));
+      try {
+        setActivity(JSON.parse(data.activity));
+      } catch (err) {
+        console.error('Failed to parse activity:', err);
+        setActivity(null);
+      }
     } catch (e) {
       console.error("Error fetching activity:", e);
     } finally {


### PR DESCRIPTION
## Summary
- use render-prop pattern for `SessionTimer`
- handle invalid JSON when parsing activity data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68538c987d1483209166af399493eec0