### PR TITLE
UI tweaks and solid background

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,7 +8,7 @@ export default function App() {
 
   if (stage === "home") return <Home onStart={() => setStage("menu")} />;
   if (stage === "menu") return <Menu onSelect={(mode) => setStage(mode)} />;
-  if (stage === "story") return <StoryMode />;
+  if (stage === "story") return <StoryMode onBack={() => setStage("menu")} />;
 
   return null;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,7 +8,7 @@
   /* Light theme by default - vibrant and bright */
   color-scheme: light;
   color: #1f2937;
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 25%, #93c5fd 50%, #60a5fa 75%, #3b82f6 100%);
+  background: #3b82f6;
   
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -27,7 +27,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 25%, #e0f2fe 50%, #b3e5fc 75%, #81d4fa 100%);
+  background: #3b82f6;
   background-attachment: fixed;
 }
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { Rocket, Stars, Zap } from "lucide-react";
 
 export default function Home({ onStart }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-200 via-ocean-100 to-adventure-100 flex flex-col items-center justify-center p-8 relative overflow-hidden">
+    <div className="min-h-screen bg-sky-200 flex flex-col items-center justify-center p-8 relative overflow-hidden">
       
       {/* Floating Background Elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -133,21 +133,6 @@ export default function Home({ onStart }) {
             Start Karl's Adventure!
           </span>
           
-          {/* Sparkle effect */}
-          <motion.div
-            className="absolute -top-2 -right-2"
-            animate={{ 
-              scale: [1, 1.2, 1],
-              rotate: [0, 180, 360]
-            }}
-            transition={{ 
-              duration: 3,
-              repeat: Infinity,
-              ease: "easeInOut"
-            }}
-          >
-            <Stars size={24} className="text-sunshine-400" />
-          </motion.div>
         </Button>
       </motion.div>
 

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -34,7 +34,7 @@ export default function Menu({ onSelect, onBack }) {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-lightMist via-sky-100 to-adventure-100 flex flex-col items-center justify-center p-8 relative">
+    <div className="min-h-screen bg-sky-200 flex flex-col items-center justify-center p-8 relative">
       
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5 pointer-events-none">
@@ -60,7 +60,7 @@ export default function Menu({ onSelect, onBack }) {
       </motion.div>
 
       {/* Menu Buttons */}
-      <div className="flex flex-col gap-8 w-full max-w-md z-10">
+      <div className="flex flex-col gap-8 w-full max-w-md z-10 items-center">
         {menuItems.map((item, index) => (
           <motion.div
             key={item.id}
@@ -78,7 +78,7 @@ export default function Menu({ onSelect, onBack }) {
               variant={item.variant}
               size="lg"
               onClick={() => onSelect(item.id)}
-              className={`w-full h-20 justify-start text-left shadow-${item.glowColor} hover:shadow-${item.glowColor} group relative overflow-hidden border-3`}
+              className={`w-72 h-20 justify-start text-left shadow-${item.glowColor} hover:shadow-${item.glowColor} group relative overflow-hidden border-3`}
             >
               {/* Background gradient animation */}
               <div className={`absolute inset-0 bg-gradient-to-r ${item.gradient} opacity-90 group-hover:opacity-100 transition-opacity duration-300`} />

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -86,7 +86,7 @@ export default function StoryMode({ onBack }) {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-lightMist via-sky-50 to-adventure-50 relative">
+    <div className="min-h-screen bg-sky-200 relative">
       
       {/* Background Elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-5">


### PR DESCRIPTION
## Summary
- make the main background a solid blue
- shrink the menu buttons
- remove the star icon from the adventure button
- allow exiting story mode back to menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538eb9c5048320a168608b4105cc78