### PR TITLE
Adjust menu layout and home screen header

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -59,22 +59,22 @@ export default function Home({ onStart }) {
       {/* Main Content */}
       <div className="text-center mb-12 z-10">
         <motion.h1
-          className="font-display text-6xl font-bold text-comicInk mb-4 drop-shadow-lg"
+          className="font-body text-7xl font-extrabold text-hero-600 mb-8 drop-shadow-lg"
           initial={{ opacity: 0, y: -50 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ 
+          transition={{
             duration: 0.8,
             ease: "easeOut"
           }}
         >
           Karl's
         </motion.h1>
-        
+
         <motion.h2
-          className="font-display text-5xl font-bold bg-gradient-to-r from-ocean-600 to-hero-600 bg-clip-text text-transparent mb-8 drop-shadow-sm"
+          className="font-body text-6xl font-extrabold text-energy-600 mb-8 drop-shadow-sm"
           initial={{ opacity: 0, y: -30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ 
+          transition={{
             duration: 0.8,
             delay: 0.2,
             ease: "easeOut"

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -59,6 +59,18 @@ export default function Menu({ onSelect, onBack }) {
         </p>
       </motion.div>
 
+      {/* Encouraging message */}
+      <motion.div
+        className="text-center mb-8 z-10"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+      >
+        <p className="text-gray-500 font-medium">
+          🌟 Every choice leads to awesome learning! 🌟
+        </p>
+      </motion.div>
+
       {/* Menu Buttons */}
       <div className="flex flex-col gap-8 w-full max-w-md z-10 items-center">
         {menuItems.map((item, index) => (
@@ -150,20 +162,6 @@ export default function Menu({ onSelect, onBack }) {
         </motion.div>
       )}
 
-      {/* Fun encouragement */}
-      <motion.div
-        className="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-center z-10"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ 
-          duration: 0.8,
-          delay: 1
-        }}
-      >
-        <p className="text-gray-500 font-medium">
-          🌟 Every choice leads to awesome learning! 🌟
-        </p>
-      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- tweak the header style on the home screen
- reposition encouragement line on the menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685391a6c90083208d50b4945dd8be64