### PR TITLE
Automated mood snapshot every 10 minutes

### DIFF
--- a/app.py
+++ b/app.py
@@ -2122,7 +2122,8 @@ async def learning_session():
             }
 
             function startMoodMonitoring() {
-                moodCheckInterval = setInterval(checkMoodAutomatically, 120000);
+                // Run automatic mood checks every 10 minutes
+                moodCheckInterval = setInterval(checkMoodAutomatically, 600000);
                 updateMoodStatus('Active 😊');
             }
 

--- a/frontend/src/WebcamSnap.jsx
+++ b/frontend/src/WebcamSnap.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Camera } from 'lucide-react';
 import { Button } from './components/ui/button';
@@ -21,6 +21,15 @@ export default function WebcamSnap({ threadId, onMood, className }) {
       console.error('Mood check failed:', e);
     }
   };
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (threadId) {
+        shoot();
+      }
+    }, 600000); // 10 minutes
+    return () => clearInterval(interval);
+  }, [threadId]);
 
   return (
     <div className={className}>


### PR DESCRIPTION
## Summary
- enable automatic mood capture in React front-end
- slow down automatic mood check interval to 10 minutes in app UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853923186dc83209ec9111c176dfc62