### PR TITLE
Implement Story Forge endpoints

### DIFF
--- a/backend/data/stories.json
+++ b/backend/data/stories.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "5122b65e-a4c3-4ee8-b23d-5e8f7177103f",
+    "user_id": "tester",
+    "date": "2025-06-19T05:20:06.955063",
+    "prompt": "A penguin",
+    "story_text": "finds treasure"
+  }
+]

--- a/backend/models/profile_v2.py
+++ b/backend/models/profile_v2.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 
 class Demographics(BaseModel):
@@ -38,9 +38,16 @@ class Typing(BaseModel):
     current_wpm: int
 
 
+class StoryBadge(BaseModel):
+    type: str
+    story_id: str
+    img_url: str
+
+
 class History(BaseModel):
     sessions_completed: int
     badges: List[str]
+    story_badges: List[StoryBadge] = []
 
 
 class LearnerProfile(BaseModel):

--- a/backend/services/story_forge.py
+++ b/backend/services/story_forge.py
@@ -1,0 +1,75 @@
+import json
+import random
+import uuid
+from datetime import datetime
+from pathlib import Path
+import shutil
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+STORIES_FILE = DATA_DIR / "stories.json"
+IMAGES_DIR = DATA_DIR / "images"
+BADGES_DIR = DATA_DIR / "badges" / "story_illustrations"
+
+IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+BADGES_DIR.mkdir(parents=True, exist_ok=True)
+
+# Simple prompt list for demonstration
+PROMPTS = [
+    "A penguin discovers a glowing compass in an ice cave...",
+    "A robot finds an ancient map under the desert sands...",
+    "An explorer stumbles upon a talking tree in the jungle...",
+]
+
+
+def _load_stories():
+    if STORIES_FILE.exists():
+        with open(STORIES_FILE) as f:
+            return json.load(f)
+    return []
+
+
+def _save_stories(stories):
+    with open(STORIES_FILE, "w") as f:
+        json.dump(stories, f, indent=2)
+
+
+def get_random_prompt() -> str:
+    """Return a random story prompt."""
+    return random.choice(PROMPTS)
+
+
+def save_story(user_id: str, prompt: str, story_text: str) -> dict:
+    """Persist a new story entry and return it."""
+    stories = _load_stories()
+    story_id = str(uuid.uuid4())
+    story = {
+        "id": story_id,
+        "user_id": user_id,
+        "date": datetime.utcnow().isoformat(),
+        "prompt": prompt,
+        "story_text": story_text,
+    }
+    stories.append(story)
+    _save_stories(stories)
+    return story
+
+
+def generate_image(prompt: str, story_text: str, story_id: str) -> str:
+    """Stubbed image generation that copies a placeholder svg."""
+    placeholder = Path(__file__).resolve().parents[2] / "frontend" / "src" / "assets" / "react.svg"
+    dest = IMAGES_DIR / f"{story_id}.svg"
+    shutil.copy(placeholder, dest)
+    return str(dest)
+
+
+def add_story_badge(profile, story_id: str, img_url: str) -> dict:
+    """Add a badge entry and copy the image under badges directory."""
+    dest = BADGES_DIR / Path(img_url).name
+    shutil.copy(img_url, dest)
+    badge = {"type": "story_illustration", "story_id": story_id, "img_url": str(dest)}
+    history = getattr(profile, "history", None)
+    if history is not None:
+        if not hasattr(history, "story_badges"):
+            history.story_badges = []
+        history.story_badges.append(badge)
+    return badge

--- a/tests/test_story_forge.py
+++ b/tests/test_story_forge.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_story_prompt():
+    resp = client.get('/story-prompt')
+    assert resp.status_code == 200
+    assert 'prompt' in resp.json()
+
+
+def test_submit_story():
+    payload = {"user_id": "tester", "prompt": "A penguin", "story_text": "finds treasure"}
+    resp = client.post('/submit-story', json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'story_id' in data and 'img_url' in data
+    img_path = pathlib.Path(data['img_url'])
+    assert img_path.exists()
+    img_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add StoryBadge model and extend History for new badge type
- implement story_forge service for prompts and story handling
- expose `/story-prompt`, `/submit-story`, and `/add-story-badge` API routes
- test the new Story Forge endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539cef91ac83209e5c99c3ea3038c9