### PR TITLE
Fix JSX closing tag error

### DIFF
--- a/frontend/src/components/TypingHomeRow.jsx
+++ b/frontend/src/components/TypingHomeRow.jsx
@@ -163,7 +163,6 @@ export default function TypingHomeRow({ onFinish }) {
           {progress.lettersCount}/{alphabet.length} letters
         </div>
       </div>
-    </div>
 
       {/* Input field */}
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 border-2 border-white/50 shadow-soft">


### PR DESCRIPTION
## Summary
- remove an extra closing `<div>` in `TypingHomeRow.jsx`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854cb0631908320b99829592687fb85