### PR TITLE
Refactor root layout and enlarge nav buttons

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,6 +34,10 @@ body {
 #root {
   min-height: 100vh;
   width: 100%;
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2rem;
 }
 
 /* Enhanced button styles */

--- a/frontend/src/pages/Accomplishments.jsx
+++ b/frontend/src/pages/Accomplishments.jsx
@@ -14,8 +14,8 @@ export default function Accomplishments({ onBack }) {
   return (
     <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
       <div className="self-start mb-6">
-        <Button variant="utility" size="md" onClick={onBack}>
-          <ArrowLeft size={20} className="mr-2" />
+        <Button variant="utility" size="lg" onClick={onBack}>
+          <ArrowLeft size={28} className="mr-2" />
           Back
         </Button>
       </div>

--- a/frontend/src/pages/DailyJournal.jsx
+++ b/frontend/src/pages/DailyJournal.jsx
@@ -43,9 +43,9 @@ export default function DailyJournal({ onBack }) {
     return (
       <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
         <div className="self-start mb-6">
-          <Button variant="utility" size="md" onClick={onBack}>
-            <ArrowLeft size={20} className="mr-2" /> Back
-          </Button>
+        <Button variant="utility" size="lg" onClick={onBack}>
+          <ArrowLeft size={28} className="mr-2" /> Back
+        </Button>
         </div>
         <div className="bg-white rounded-2xl p-6 w-full max-w-lg shadow-soft">
           <p className="mb-4 text-gray-700 whitespace-pre-wrap">{entry}</p>
@@ -69,9 +69,9 @@ export default function DailyJournal({ onBack }) {
     return (
       <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
         <div className="self-start mb-6">
-          <Button variant="utility" size="md" onClick={onBack}>
-            <ArrowLeft size={20} className="mr-2" /> Back
-          </Button>
+        <Button variant="utility" size="lg" onClick={onBack}>
+          <ArrowLeft size={28} className="mr-2" /> Back
+        </Button>
         </div>
         <div className="bg-white rounded-2xl p-6 w-full max-w-lg text-center shadow-soft">
           <p className="font-semibold text-comicInk">Thanks for journaling today!</p>
@@ -83,8 +83,8 @@ export default function DailyJournal({ onBack }) {
   return (
     <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
       <div className="self-start mb-6">
-        <Button variant="utility" size="md" onClick={onBack}>
-          <ArrowLeft size={20} className="mr-2" /> Back
+        <Button variant="utility" size="lg" onClick={onBack}>
+          <ArrowLeft size={28} className="mr-2" /> Back
         </Button>
       </div>
       <div className="bg-white rounded-2xl p-6 w-full max-w-lg shadow-soft">

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -161,11 +161,11 @@ export default function Menu({ onSelect, onBack }) {
         >
           <Button
             variant="utility"
-            size="md"
+            size="lg"
             onClick={onBack}
             className="hover:shadow-medium"
           >
-            <ArrowLeft size={20} className="mr-2" />
+            <ArrowLeft size={28} className="mr-2" />
             Back to Home
           </Button>
         </motion.div>

--- a/frontend/src/pages/StoryForge.jsx
+++ b/frontend/src/pages/StoryForge.jsx
@@ -43,9 +43,9 @@ export default function StoryForge({ onBack }) {
     return (
       <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
         <div className="self-start mb-6">
-          <Button variant="utility" size="md" onClick={() => { setImageUrl(null); setStory(''); }}>
-            <ArrowLeft size={20} className="mr-2" /> New Story
-          </Button>
+        <Button variant="utility" size="lg" onClick={() => { setImageUrl(null); setStory(''); }}>
+          <ArrowLeft size={28} className="mr-2" /> New Story
+        </Button>
         </div>
         <img src={imageUrl} alt="Story illustration" className="max-w-md rounded-xl border-2" />
       </div>
@@ -55,8 +55,8 @@ export default function StoryForge({ onBack }) {
   return (
     <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
       <div className="self-start mb-6">
-        <Button variant="utility" size="md" onClick={onBack}>
-          <ArrowLeft size={20} className="mr-2" /> Back
+        <Button variant="utility" size="lg" onClick={onBack}>
+          <ArrowLeft size={28} className="mr-2" /> Back
         </Button>
       </div>
       <motion.h1

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -150,11 +150,11 @@ export default function StoryMode({ onBack }) {
 
             <Button
               variant="utility"
-              size="sm"
+              size="lg"
               onClick={onBack}
               className="hover:shadow-medium"
             >
-              <Home size={16} className="mr-2" />
+              <Home size={28} className="mr-2" />
               Exit
             </Button>
           </motion.div>

--- a/frontend/src/pages/TypingChallenge.jsx
+++ b/frontend/src/pages/TypingChallenge.jsx
@@ -34,8 +34,8 @@ export default function TypingChallenge({ onBack }) {
     return (
       <div className="min-h-screen bg-sky-200 p-8 flex flex-col items-center">
         <div className="self-start mb-6">
-          <Button variant="utility" size="md" onClick={() => setActivity(null)}>
-            <ArrowLeft size={20} className="mr-2" />
+          <Button variant="utility" size="lg" onClick={() => setActivity(null)}>
+            <ArrowLeft size={28} className="mr-2" />
             Back
           </Button>
         </div>
@@ -109,8 +109,8 @@ export default function TypingChallenge({ onBack }) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, delay: 0.6 }}
       >
-        <Button variant="utility" size="md" onClick={onBack} className="hover:shadow-medium">
-          <ArrowLeft size={20} className="mr-2" />
+      <Button variant="utility" size="lg" onClick={onBack} className="hover:shadow-medium">
+          <ArrowLeft size={28} className="mr-2" />
           Back to Menu
         </Button>
       </motion.div>


### PR DESCRIPTION
## Summary
- limit root container width and center content
- increase the size of Back and Home buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854edc83da483208479b6dda4eb09b7