### PR TITLE
Adjust typing challenge styles

### DIFF
--- a/frontend/src/components/TypingHomeRow.jsx
+++ b/frontend/src/components/TypingHomeRow.jsx
@@ -137,7 +137,7 @@ export default function TypingHomeRow({ onFinish }) {
       </div>
 
       {/* Text to type */}
-      <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 mb-4 border-2 border-white/50 shadow-soft">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-8 mb-4 border-2 border-white/50 shadow-soft">
         <label className="block text-sm font-semibold text-gray-700 mb-3">
           Type this text:
         </label>
@@ -149,7 +149,7 @@ export default function TypingHomeRow({ onFinish }) {
       </div>
 
       {/* Mastery progress bar */}
-      <div className="mt-6">
+      <div className="mt-6 py-4">
         <label className="block text-sm font-semibold text-gray-700 mb-2">Mastery Progress:</label>
         <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
           <motion.div
@@ -165,7 +165,7 @@ export default function TypingHomeRow({ onFinish }) {
       </div>
 
       {/* Input field */}
-      <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 border-2 border-white/50 shadow-soft">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-8 border-2 border-white/50 shadow-soft">
         <label className="block text-sm font-semibold text-gray-700 mb-3">
           Your typing:
         </label>
@@ -185,7 +185,7 @@ export default function TypingHomeRow({ onFinish }) {
         />
         
         {/* Progress indicator */}
-        <div className="mt-4 flex items-center justify-between">
+        <div className="mt-4 flex items-center justify-between py-4">
           <div className="flex items-center gap-2 text-sm">
             <span className="text-gray-600">Progress:</span>
             <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">

--- a/frontend/src/pages/TypingChallenge.jsx
+++ b/frontend/src/pages/TypingChallenge.jsx
@@ -70,7 +70,7 @@ export default function TypingChallenge({ onBack }) {
         </p>
       </motion.div>
 
-      <div className="flex flex-col gap-8 w-full max-w-md items-center">
+      <div className="flex flex-col gap-12 w-full max-w-md items-center">
         {activities.map((item, index) => (
           <motion.div
             key={item.id}
@@ -88,15 +88,15 @@ export default function TypingChallenge({ onBack }) {
                 if (item.id === 'forge') setActivity('forge');
                 if (item.id === 'journal') setActivity('journal');
               }}
-              className="w-72 h-20 justify-start text-left border-3"
+              className="w-[300px] h-20 justify-start text-left border-3"
             >
               <div className="absolute inset-0 bg-gradient-to-r from-energy-400 to-energy-600 opacity-90" />
               <motion.div className="relative z-10 mr-6 p-3 bg-white/20 rounded-xl backdrop-blur-sm">
                 <item.icon size={32} className="text-white" />
               </motion.div>
               <div className="relative z-10 flex-1">
-                <h3 className="text-2xl font-bold text-white mb-1">{item.title}</h3>
-                <p className="text-white/90 text-sm font-medium">{item.subtitle}</p>
+                <h3 className="text-3xl font-bold text-white mb-1">{item.title}</h3>
+                <p className="text-white/90 text-base font-medium">{item.subtitle}</p>
               </div>
             </Button>
           </motion.div>


### PR DESCRIPTION
## Summary
- add extra padding on Typing Basics rows
- enlarge challenge buttons on Typing Challenge page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685584a7b5bc8320a5c361516f8fda46