### PR TITLE
Fix duplicate cn definition

### DIFF
--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { cn } from "../../lib/utils"; // You may need to create this utility
+import { cn } from "../../lib/utils";
 
 const Button = forwardRef(({ className, variant, size, ...props }, ref) => {
   return (
@@ -60,10 +60,6 @@ const buttonVariants = ({ variant, size, className }) => {
   return `${base} ${variants[variant] || variants.default} ${sizes[size] || sizes.default} ${className || ''}`;
 };
 
-// Utility function for className merging (create this file if it doesn't exist)
-// src/lib/utils.js
-function cn(...classes) {
-  return classes.filter(Boolean).join(' ');
-}
+
 
 export { Button, buttonVariants };

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- create `src/lib/utils.js` with `cn` helper
- remove duplicate definition from Button component

## Testing
- `npm --prefix frontend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68559b6fb4bc832098a308632f2633de