### PR TITLE
Fix grid and box shadow utilities

### DIFF
--- a/frontend/tailwind.config.jsx
+++ b/frontend/tailwind.config.jsx
@@ -168,6 +168,7 @@ module.exports = {
         'glow-green': '0 0 20px rgba(34, 197, 94, 0.15)',
         'glow-purple': '0 0 20px rgba(168, 85, 247, 0.15)',
         'glow-yellow': '0 0 20px rgba(245, 158, 11, 0.15)',
+        'glow-orange': '0 0 20px rgba(249, 115, 22, 0.15)',
       },
       
       animation: {
@@ -188,7 +189,11 @@ module.exports = {
           '100%': { opacity: '1', transform: 'translateY(0)' },
         }
       },
-      
+
+      gridTemplateColumns: {
+        '13': 'repeat(13, minmax(0, 1fr))',
+      },
+
       spacing: {
         // Professional spacing scale
         '18': '4.5rem',   // 72px


### PR DESCRIPTION
## Summary
- add custom `glow-orange` box shadow
- extend Tailwind grid template columns to include 13 columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855babb56e08320afb6149a8f3f300c