### PR TITLE
Add GPT image generation to Story Forge

### DIFF
--- a/frontend/src/pages/Accomplishments.jsx
+++ b/frontend/src/pages/Accomplishments.jsx
@@ -1,14 +1,17 @@
 import { useState, useEffect } from 'react';
-import { Award, Trophy, Target, TrendingUp, Calendar } from 'lucide-react';
+import { Award, Trophy, Target, TrendingUp, Calendar, PenTool } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Button } from '../components/ui/button';
 import { loadProgress, alphabet } from '../utils/typingProgress';
+import { loadStoryImages } from '../utils/storyImages';
 
 export default function Accomplishments({ onBack }) {
   const [progress, setProgress] = useState(() => loadProgress());
+  const [storyImages, setStoryImages] = useState(() => loadStoryImages());
 
   useEffect(() => {
     setProgress(loadProgress());
+    setStoryImages(loadStoryImages());
   }, []);
 
   const progressPercentage = (progress.lettersCount / alphabet.length) * 100;
@@ -242,6 +245,26 @@ export default function Accomplishments({ onBack }) {
           </div>
         )}
       </motion.div>
+
+      {/* Story Illustrations */}
+      {storyImages.length > 0 && (
+        <motion.div
+          className="bg-white rounded-lg shadow-sm border border-slate-200 p-6"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.5 }}
+        >
+          <div className="flex items-center space-x-3 mb-4">
+            <PenTool className="h-6 w-6 text-purple-600" />
+            <h3 className="text-lg font-semibold text-slate-900">Story Illustrations</h3>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            {storyImages.map((url, idx) => (
+              <img key={idx} src={url} alt="Story" className="w-32 h-32 object-cover rounded" />
+            ))}
+          </div>
+        </motion.div>
+      )}
 
       {/* Encouragement Message */}
       <motion.div

--- a/frontend/src/pages/StoryForge.jsx
+++ b/frontend/src/pages/StoryForge.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { Button } from '../components/ui/button';
 import { ArrowLeft, PenTool, Loader2, CheckCircle } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { addStoryImage } from '../utils/storyImages';
 
 export default function StoryForge({ onBack }) {
   const [prompt, setPrompt] = useState('');
@@ -37,6 +38,7 @@ export default function StoryForge({ onBack }) {
         story_text: story,
       });
       setImageUrl(data.img_url);
+      addStoryImage(data.img_url);
     } catch (e) {
       console.error('Failed to submit story', e);
       setError('Failed to submit your story. Please try again.');

--- a/frontend/src/utils/storyImages.js
+++ b/frontend/src/utils/storyImages.js
@@ -1,0 +1,18 @@
+export function loadStoryImages() {
+  try {
+    const stored = localStorage.getItem('storyImages');
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveStoryImages(images) {
+  localStorage.setItem('storyImages', JSON.stringify(images));
+}
+
+export function addStoryImage(url) {
+  const images = loadStoryImages();
+  images.push(url);
+  saveStoryImages(images);
+}

--- a/tests/test_story_forge.py
+++ b/tests/test_story_forge.py
@@ -20,6 +20,7 @@ def test_submit_story():
     assert resp.status_code == 200
     data = resp.json()
     assert 'story_id' in data and 'img_url' in data
+    assert data['img_url'].endswith('.jpeg')
     img_path = pathlib.Path(data['img_url'])
     assert img_path.exists()
     img_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- implement OpenAI based image generation with local fallback
- store story illustration urls in local storage
- display saved illustrations on accomplishments page
- update tests for jpeg image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f00760348320beea2fd30b40b61e