### PR TITLE
Add Choose Your Own Adventure page

### DIFF
--- a/frontend/src/AudioRecorder.jsx
+++ b/frontend/src/AudioRecorder.jsx
@@ -25,8 +25,8 @@ export default function AudioRecorder({ threadId, passageText, afterSubmit, clas
         form.append('thread_id', threadId);
         form.append('passage', passageText);
         form.append('audio', file);
-        await axios.post('/api/submit_audio', form);
-        afterSubmit();
+        const { data } = await axios.post('/api/submit_audio', form);
+        afterSubmit(data);
         setRecorder(null);
         setIsRecording(false);
       };

--- a/frontend/src/pages/ChooseAdventure.jsx
+++ b/frontend/src/pages/ChooseAdventure.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import AudioRecorder from '../AudioRecorder';
+
+const STORY_PARTS = [
+  {
+    text: `Karl had always dreamed of exploring hidden worlds. Today, a shimmering gateway opened before him. With a deep breath, he stepped through and found himself in a realm of magic and mystery.
+
+The air sparkled with possibility as he looked around. Nearby, two paths beckoned for adventure.`,
+    options: ['Take the path through the singing forest', 'Enter the cave of echoes']
+  },
+  {
+    text: `Karl pressed onward, feeling brave after his first choice. The landscape shifted with every step, revealing wonders beyond imagination.`,
+    options: ['Follow the river of light', 'Climb the floating staircase']
+  },
+  {
+    text: `Up ahead, strange creatures waved hello. They whispered clues about a hidden treasure lost for centuries.`,
+    options: ['Ask the creatures for help', 'Continue alone toward the ruins']
+  },
+  {
+    text: `A gentle breeze carried the scent of adventure. Karl felt more confident with each decision.`,
+    options: ['Search the crystal tower', 'Explore the underground tunnel']
+  },
+  {
+    text: `Lights twinkled in the distance, guiding Karl toward his next discovery.`,
+    options: ['Head toward the twinkling lights', 'Rest beside the glowing pond']
+  },
+  {
+    text: `Every choice led Karl deeper into the story. He wondered what surprises awaited next.`,
+    options: ['Inspect the mysterious footprints', 'Follow the singing birds']
+  },
+  {
+    text: `Karl felt the adventure nearing its peak. The world around him buzzed with energy.`,
+    options: ['Enter the grand library', 'Speak the secret password']
+  },
+  {
+    text: `Only a few steps remained before the tale would end. Karl took a deep breath and prepared for the finale.`,
+    options: ['Open the ancient door', 'Step onto the glowing platform']
+  },
+  {
+    text: `With a triumphant smile, Karl realized he had completed his quest. The world shimmered once more as the gateway home appeared.`,
+    options: []
+  }
+];
+
+export default function ChooseAdventure({ onBack }) {
+  const [index, setIndex] = useState(0);
+  const [recorded, setRecorded] = useState(false);
+  const [stats, setStats] = useState([]);
+  const [path, setPath] = useState([]);
+
+  const handleAudioDone = (data) => {
+    setRecorded(true);
+    if (data) {
+      const accuracy = data.words_total ? Math.round((data.words_correct / data.words_total) * 100) : 0;
+      setStats([...stats, { wpm: data.words_per_minute, accuracy }]);
+    }
+  };
+
+  const handleChoice = (option) => {
+    setPath([...path, option]);
+    setRecorded(false);
+    const next = index + 1;
+    if (next >= STORY_PARTS.length) {
+      setIndex(STORY_PARTS.length);
+    } else {
+      setIndex(next);
+    }
+  };
+
+  if (index >= STORY_PARTS.length) {
+    const avgWpm = stats.reduce((a, b) => a + b.wpm, 0) / stats.length || 0;
+    const avgAcc = stats.reduce((a, b) => a + b.accuracy, 0) / stats.length || 0;
+    const summary = STORY_PARTS.map(p => p.text).join(' ');
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center space-x-3">
+          <Button variant="ghost" onClick={onBack}>
+            <ArrowLeft className="h-5 w-5 mr-2" />Back
+          </Button>
+        </div>
+        <h1 className="text-2xl font-bold">Adventure Complete!</h1>
+        <p>Great job reading through the story.</p>
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <p className="font-medium">🏅 Reading Badge Earned!</p>
+          <p className="text-sm mt-2">{summary.slice(0, 120)}...</p>
+        </div>
+        <p className="text-sm">Average Speed: {avgWpm.toFixed(1)} WPM</p>
+        <p className="text-sm">Average Accuracy: {avgAcc.toFixed(1)}%</p>
+      </div>
+    );
+  }
+
+  const part = STORY_PARTS[index];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-3">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="h-5 w-5 mr-2" />Back
+        </Button>
+        <h1 className="text-2xl font-bold">Choose Your Own Adventure!</h1>
+      </div>
+
+      <p className="whitespace-pre-line text-lg">{part.text}</p>
+
+      {!recorded && (
+        <AudioRecorder
+          threadId={`adv-${index}`}
+          passageText={part.text}
+          afterSubmit={handleAudioDone}
+        />
+      )}
+
+      {recorded && part.options.length > 0 && (
+        <div className="space-y-3">
+          {part.options.map((opt) => (
+            <Button key={opt} onClick={() => handleChoice(opt)} className="w-full">
+              {opt}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {recorded && part.options.length === 0 && (
+        <Button onClick={() => handleChoice('end')}>Next</Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/FunFacts.jsx
+++ b/frontend/src/pages/FunFacts.jsx
@@ -1,0 +1,16 @@
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '../components/ui/button';
+
+export default function FunFacts({ onBack }) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-3">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="h-5 w-5 mr-2" />Back
+        </Button>
+        <h1 className="text-2xl font-bold">Fun Facts</h1>
+      </div>
+      <p className="text-lg text-slate-700">This section will contain interesting facts to explore. Stay tuned!</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -20,6 +20,9 @@ import ActivityBox from '../ActivityBox';
 import SessionTimer from '../components/SessionTimer';
 import TypingHomeRow from '../components/TypingHomeRow';
 import ComicPad from '../components/ComicPad';
+import ChooseAdventure from './ChooseAdventure';
+import StoryForge from './StoryForge';
+import FunFacts from './FunFacts';
 
 const profile = { attention: { session_max_minutes: 30 } };
 
@@ -30,8 +33,19 @@ export default function StoryMode({ onBack }) {
   const [loading, setLoading] = useState(false);
   const [showComic, setShowComic] = useState(false);
   const [sessionStarted, setSessionStarted] = useState(false);
-  
+  const [mode, setMode] = useState(null);
+
   const readAloudText = activity?.read_aloud || "";
+
+  if (mode === 'choose') {
+    return <ChooseAdventure onBack={() => setMode(null)} />;
+  }
+  if (mode === 'create') {
+    return <StoryForge onBack={() => setMode(null)} />;
+  }
+  if (mode === 'facts') {
+    return <FunFacts onBack={() => setMode(null)} />;
+  }
 
   useEffect(() => {
     const openComic = () => setShowComic(true);
@@ -184,27 +198,32 @@ export default function StoryMode({ onBack }) {
                 </p>
               </div>
 
-              <motion.div
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-              >
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <Button
                   variant="hero"
-                  size="xxl"
-                  onClick={newSession}
-                  loading={loading}
-                  className="shadow-2xl hover:shadow-glow-blue border-4 border-ocean-300"
+                  size="lg"
+                  onClick={() => setMode('choose')}
+                  className="w-full"
                 >
-                  <Rocket size={40} className="mr-4" />
-                  <span className="text-white font-bold">
-                    {loading ? "Starting Adventure..." : "🚀 Start Karl's Adventure"}
-                  </span>
+                  Choose Your Own Adventure
                 </Button>
-              </motion.div>
-
-              <p className="mt-6 text-gray-600 font-medium">
-                Click to begin your personalized learning session!
-              </p>
+                <Button
+                  variant="hero"
+                  size="lg"
+                  onClick={() => setMode('create')}
+                  className="w-full"
+                >
+                  Story Creation
+                </Button>
+                <Button
+                  variant="hero"
+                  size="lg"
+                  onClick={() => setMode('facts')}
+                  className="w-full"
+                >
+                  Fun Facts
+                </Button>
+              </div>
             </motion.div>
           ) : (
             /* Active Session Interface */


### PR DESCRIPTION
## Summary
- add `ChooseAdventure` interactive story page
- add placeholder `FunFacts` page
- return audio metrics from `AudioRecorder`
- update `StoryMode` with buttons for Choose Adventure, Story Creation, and Fun Facts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f7d6d94c832088c3210de151d41a