### PR TITLE
Add story creation page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.2.0",
     "react-webcam": "^7.2.0",
     "lucide-react": "^0.322.0",
-    "framer-motion": "^10.16.3"
+    "framer-motion": "^10.16.3",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/pages/Accomplishments.jsx
+++ b/frontend/src/pages/Accomplishments.jsx
@@ -4,14 +4,17 @@ import { motion } from 'framer-motion';
 import { Button } from '../components/ui/button';
 import { loadProgress, alphabet } from '../utils/typingProgress';
 import { loadStoryImages } from '../utils/storyImages';
+import { loadStoryPDFs } from '../utils/storyPDFs';
 
 export default function Accomplishments({ onBack }) {
   const [progress, setProgress] = useState(() => loadProgress());
   const [storyImages, setStoryImages] = useState(() => loadStoryImages());
+  const [storyPDFs, setStoryPDFs] = useState(() => loadStoryPDFs());
 
   useEffect(() => {
     setProgress(loadProgress());
     setStoryImages(loadStoryImages());
+    setStoryPDFs(loadStoryPDFs());
   }, []);
 
   const progressPercentage = (progress.lettersCount / alphabet.length) * 100;
@@ -263,6 +266,29 @@ export default function Accomplishments({ onBack }) {
               <img key={idx} src={url} alt="Story" className="w-32 h-32 object-cover rounded" />
             ))}
           </div>
+        </motion.div>
+      )}
+
+      {storyPDFs.length > 0 && (
+        <motion.div
+          className="bg-white rounded-lg shadow-sm border border-slate-200 p-6"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.5 }}
+        >
+          <div className="flex items-center space-x-3 mb-4">
+            <PenTool className="h-6 w-6 text-purple-600" />
+            <h3 className="text-lg font-semibold text-slate-900">Created Stories</h3>
+          </div>
+          <ul className="list-disc pl-6 space-y-2">
+            {storyPDFs.map((url, idx) => (
+              <li key={idx}>
+                <a href={url} download={`story-${idx + 1}.pdf`} className="text-blue-600 underline">
+                  Download Story {idx + 1}
+                </a>
+              </li>
+            ))}
+          </ul>
         </motion.div>
       )}
 

--- a/frontend/src/pages/StoryCreation.jsx
+++ b/frontend/src/pages/StoryCreation.jsx
@@ -1,0 +1,171 @@
+import { useState, useRef } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { jsPDF } from 'jspdf';
+import { Button } from '../components/ui/button';
+import { addStoryPDF } from '../utils/storyPDFs';
+
+export default function StoryCreation({ onBack }) {
+  const [title, setTitle] = useState('');
+  const [chapterName, setChapterName] = useState('');
+  const [body, setBody] = useState('');
+  const [chapters, setChapters] = useState([]);
+  const [showCanvas, setShowCanvas] = useState(false);
+  const canvasRef = useRef(null);
+  const [drawing, setDrawing] = useState(false);
+
+  const startDraw = (e) => {
+    if (!showCanvas) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.beginPath();
+    ctx.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+    setDrawing(true);
+  };
+
+  const draw = (e) => {
+    if (!drawing || !showCanvas) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.lineTo(e.clientX - rect.left, e.clientY - rect.top);
+    ctx.stroke();
+  };
+
+  const endDraw = () => {
+    if (!showCanvas) return;
+    setDrawing(false);
+  };
+
+  const clearCanvas = () => {
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+  };
+
+  const captureDrawing = () => {
+    if (showCanvas && canvasRef.current) {
+      return canvasRef.current.toDataURL('image/png');
+    }
+    return null;
+  };
+
+  const addChapter = () => {
+    const illustration = captureDrawing();
+    const chapter = { name: chapterName, text: body, illustration };
+    setChapters([...chapters, chapter]);
+    setChapterName('');
+    setBody('');
+    clearCanvas();
+  };
+
+  const handleDoneChapter = () => {
+    if (!window.confirm('Are you sure you are done with this chapter?')) return;
+    addChapter();
+  };
+
+  const generatePDF = (allChapters) => {
+    const doc = new jsPDF();
+    doc.setFontSize(16);
+    doc.text(title || 'My Story', 10, 20);
+    allChapters.forEach((ch, idx) => {
+      if (idx > 0 || title) doc.addPage();
+      doc.setFontSize(14);
+      if (ch.name) doc.text(ch.name, 10, 30);
+      doc.setFontSize(12);
+      doc.text(ch.text || '', 10, 40, { maxWidth: 180 });
+      if (ch.illustration) {
+        try {
+          doc.addImage(ch.illustration, 'PNG', 10, 80, 100, 100);
+        } catch {}
+      }
+    });
+    const dataUrl = doc.output('datauristring');
+    addStoryPDF(dataUrl);
+    doc.save('story.pdf');
+  };
+
+  const handleDoneStory = () => {
+    if (!window.confirm('Are you sure you are finished with this story?')) return;
+    const illustration = captureDrawing();
+    const finalChapters = [...chapters, { name: chapterName, text: body, illustration }];
+    generatePDF(finalChapters);
+    setTitle('');
+    setChapterName('');
+    setBody('');
+    setChapters([]);
+    clearCanvas();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-3">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="h-5 w-5 mr-2" />Back
+        </Button>
+        <h1 className="text-2xl font-bold">Story Creation</h1>
+      </div>
+
+      <div className="space-y-4 bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Story Title</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Chapter Name</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={chapterName}
+            onChange={(e) => setChapterName(e.target.value)}
+            placeholder="Chapter name"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Story Text</label>
+          <textarea
+            className="w-full h-48 p-3 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Write your story..."
+          />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <Button onClick={() => setShowCanvas(!showCanvas)} className="w-full" variant="secondary">
+          {showCanvas ? 'Hide Illustration' : 'Optional Illustration'}
+        </Button>
+        {showCanvas && (
+          <div className="border border-slate-300 p-2 rounded">
+            <canvas
+              ref={canvasRef}
+              width={300}
+              height={300}
+              className="border border-slate-200"
+              onMouseDown={startDraw}
+              onMouseMove={draw}
+              onMouseUp={endDraw}
+              onMouseLeave={endDraw}
+            />
+            <div className="mt-2">
+              <Button size="sm" variant="ghost" onClick={clearCanvas}>Clear</Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex space-x-3">
+        <Button onClick={handleDoneChapter} className="w-full">
+          Done with Chapter
+        </Button>
+        <Button onClick={handleDoneStory} variant="hero" className="w-full">
+          Done with Story
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -21,7 +21,7 @@ import SessionTimer from '../components/SessionTimer';
 import TypingHomeRow from '../components/TypingHomeRow';
 import ComicPad from '../components/ComicPad';
 import ChooseAdventure from './ChooseAdventure';
-import StoryForge from './StoryForge';
+import StoryCreation from './StoryCreation';
 import FunFacts from './FunFacts';
 
 const profile = { attention: { session_max_minutes: 30 } };
@@ -41,7 +41,7 @@ export default function StoryMode({ onBack }) {
     return <ChooseAdventure onBack={() => setMode(null)} />;
   }
   if (mode === 'create') {
-    return <StoryForge onBack={() => setMode(null)} />;
+    return <StoryCreation onBack={() => setMode(null)} />;
   }
   if (mode === 'facts') {
     return <FunFacts onBack={() => setMode(null)} />;

--- a/frontend/src/utils/storyPDFs.js
+++ b/frontend/src/utils/storyPDFs.js
@@ -1,0 +1,18 @@
+export function loadStoryPDFs() {
+  try {
+    const stored = localStorage.getItem('storyPDFs');
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveStoryPDFs(pdfs) {
+  localStorage.setItem('storyPDFs', JSON.stringify(pdfs));
+}
+
+export function addStoryPDF(dataUrl) {
+  const pdfs = loadStoryPDFs();
+  pdfs.push(dataUrl);
+  saveStoryPDFs(pdfs);
+}


### PR DESCRIPTION
## Summary
- add new `StoryCreation` page with drawing canvas and PDF export
- save created stories in local storage and show downloads on Accomplishments page
- wire StoryMode second button to new page
- support storing generated PDFs via new utility
- include `jspdf` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685635acbd5c83208ce4997db66b197a