### PR TITLE
Fix jsPDF import path in StoryCreation

### DIFF
--- a/frontend/src/pages/StoryCreation.jsx
+++ b/frontend/src/pages/StoryCreation.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import { jsPDF } from 'jspdf';
+import jsPDF from 'jspdf';
 import { Button } from '../components/ui/button';
 import { addStoryPDF } from '../utils/storyPDFs';
 


### PR DESCRIPTION
## Summary
- fix StoryCreation.jsx jsPDF import to use default import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68574ff457ec8320b51ea58591423d93