### PR TITLE
Adjust menu timing and layout width

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,7 +54,7 @@ export default function App() {
       {/* Professional Navigation Header */}
       {showNavigation && (
         <nav className="bg-white shadow-sm border-b border-slate-200">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-[1100px] mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between h-16">
               <div className="flex items-center">
                 <BookOpen className="h-8 w-8 text-blue-600 mr-3" />
@@ -88,7 +88,7 @@ export default function App() {
       )}
 
       {/* Main Content */}
-      <main className={showNavigation ? "max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8" : ""}>
+      <main className={showNavigation ? "max-w-[1100px] mx-auto py-6 px-4 sm:px-6 lg:px-8" : ""}>
         {stage === "home" && <HomePage onStart={() => setStage("menu")} />}
         {stage === "menu" && <Menu onSelect={(mode) => setStage(mode)} onBack={() => setStage("home")} />}
         {stage === "story" && <StoryMode onBack={() => setStage("menu")} />}

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -70,11 +70,11 @@ export default function Menu({ onSelect, onBack }) {
             key={item.id}
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ 
-              duration: 0.6,
-              delay: index * 0.1,
-              ease: "easeOut"
-            }}
+              transition={{
+                duration: 0.6,
+                delay: index * 0.05,
+                ease: "easeOut"
+              }}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >


### PR DESCRIPTION
## Summary
- reduce framer-motion delay on adventure menu buttons
- limit app width to 1100px with side padding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575636179c83209012b04ee531d8e7