### PR TITLE
Modify StoryMode hero buttons

### DIFF
--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -203,25 +203,25 @@ export default function StoryMode({ onBack }) {
                   variant="hero"
                   size="lg"
                   onClick={() => setMode('choose')}
-                  className="w-full"
+                  className="w-[500px] h-[100px] p-[50px]"
                 >
-                  Choose Your Own Adventure
+                  🏔️ Choose Your Own Adventure 🗺️
                 </Button>
                 <Button
                   variant="hero"
                   size="lg"
                   onClick={() => setMode('create')}
-                  className="w-full"
+                  className="w-[500px] h-[100px] p-[50px]"
                 >
-                  Story Creation
+                  📖 Story Creation 📝
                 </Button>
                 <Button
                   variant="hero"
                   size="lg"
                   onClick={() => setMode('facts')}
-                  className="w-full"
+                  className="w-[500px] h-[100px] p-[50px]"
                 >
-                  Fun Facts
+                  🧪🗿 Fun Facts 🌍🚀
                 </Button>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- widen main hero buttons to 500x100 with 50px padding
- add themed emojis for each button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685759c658408320b284e4102acb7d71