### PR TITLE
Fix navigation and progress tracking

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -65,10 +65,15 @@ export default function App() {
                   {getNavItems().map((item) => (
                     <button
                       key={item.id}
-                      onClick={() => setStage(item.id)}
+                      onClick={() => {
+                        if (item.id === 'game' && stage === 'game') {
+                          window.dispatchEvent(new Event('reset-typing-challenge'));
+                        }
+                        setStage(item.id);
+                      }}
                       className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                        item.active 
-                          ? 'bg-blue-100 text-blue-700' 
+                        item.active
+                          ? 'bg-blue-100 text-blue-700'
                           : 'text-slate-600 hover:text-slate-900 hover:bg-slate-50'
                       }`}
                     >

--- a/frontend/src/components/TypingHomeRow.jsx
+++ b/frontend/src/components/TypingHomeRow.jsx
@@ -159,10 +159,26 @@ export default function TypingHomeRow({ onFinish }) {
             transition={{ duration: 0.5 }}
           />
         </div>
-        <div className="text-right text-xs font-mono text-gray-600 mt-1">
-          {progress.lettersCount}/{alphabet.length} letters
-        </div>
+      <div className="text-right text-xs font-mono text-gray-600 mt-1">
+        {progress.lettersCount}/{alphabet.length} letters
       </div>
+    </div>
+
+    {/* Attempt progress bar */}
+    <div className="mt-4">
+      <label className="block text-sm font-semibold text-gray-700 mb-2">Attempt Progress:</label>
+      <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
+        <motion.div
+          className="h-full bg-gradient-to-r from-ocean-400 to-ocean-600"
+          initial={{ width: 0 }}
+          animate={{ width: `${(progress.streak / 5) * 100}%` }}
+          transition={{ duration: 0.5 }}
+        />
+      </div>
+      <div className="text-right text-xs font-mono text-gray-600 mt-1">
+        {progress.streak}/5 attempts
+      </div>
+    </div>
 
       {/* Input field */}
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl px-6 py-8 border-2 border-white/50 shadow-soft">

--- a/frontend/src/pages/TypingChallenge.jsx
+++ b/frontend/src/pages/TypingChallenge.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '../components/ui/button';
 import TypingHomeRow from '../components/TypingHomeRow';
 import StoryForge from './StoryForge';
@@ -8,6 +8,12 @@ import { motion } from 'framer-motion';
 
 export default function TypingChallenge({ onBack }) {
   const [activity, setActivity] = useState(null);
+
+  useEffect(() => {
+    const handler = () => setActivity(null);
+    window.addEventListener('reset-typing-challenge', handler);
+    return () => window.removeEventListener('reset-typing-challenge', handler);
+  }, []);
 
   const activities = [
     {
@@ -54,7 +60,7 @@ export default function TypingChallenge({ onBack }) {
   if (activity === 'basics') {
     return (
       <div className="space-y-6">
-        <div className="flex items-center space-x-3">
+        <div className="flex items-center space-x-3 pl-2 mt-4">
           <Keyboard className="h-8 w-8 text-blue-600" />
           <div>
             <h1 className="text-2xl font-bold text-slate-900">Typing Basics</h1>


### PR DESCRIPTION
## Summary
- dispatch event when clicking active Typing Challenge nav item
- reset activity in TypingChallenge when event fires and pad page banner
- show attempts needed for next letter in TypingHomeRow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577ad3a6a0832082e53272e0a379e3