### PR TITLE
Fix StoryMode mode switch rendering

### DIFF
--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -37,16 +37,6 @@ export default function StoryMode({ onBack }) {
 
   const readAloudText = activity?.read_aloud || "";
 
-  if (mode === 'choose') {
-    return <ChooseAdventure onBack={() => setMode(null)} />;
-  }
-  if (mode === 'create') {
-    return <StoryCreation onBack={() => setMode(null)} />;
-  }
-  if (mode === 'facts') {
-    return <FunFacts onBack={() => setMode(null)} />;
-  }
-
   useEffect(() => {
     const openComic = () => setShowComic(true);
     window.addEventListener('comic-break', openComic);
@@ -108,6 +98,16 @@ export default function StoryMode({ onBack }) {
       setLoading(false);
     }
   };
+
+  if (mode === 'choose') {
+    return <ChooseAdventure onBack={() => setMode(null)} />;
+  }
+  if (mode === 'create') {
+    return <StoryCreation onBack={() => setMode(null)} />;
+  }
+  if (mode === 'facts') {
+    return <FunFacts onBack={() => setMode(null)} />;
+  }
 
   return (
     <div className="min-h-screen bg-sky-200 relative">


### PR DESCRIPTION
## Summary
- fix missing hooks error by moving ChooseAdventure/StoryCreation/FunFacts conditional return after hooks in `StoryMode`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577b9b29f88320a08a94f1269c9ccf