### PR TITLE
Fix hero button text size in StoryMode

### DIFF
--- a/frontend/src/pages/StoryMode.jsx
+++ b/frontend/src/pages/StoryMode.jsx
@@ -204,7 +204,6 @@ export default function StoryMode({ onBack }) {
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6 place-items-center">
                 <Button
                   variant="hero"
-                  size="lg"
                   onClick={() => setMode('choose')}
                   className="w-[500px] h-[100px] p-[50px] text-5xl flex items-center justify-center"
                 >
@@ -214,7 +213,6 @@ export default function StoryMode({ onBack }) {
                 </Button>
                 <Button
                   variant="hero"
-                  size="lg"
                   onClick={() => setMode('create')}
                   className="w-[500px] h-[100px] p-[50px] text-5xl flex items-center justify-center"
                 >
@@ -224,7 +222,6 @@ export default function StoryMode({ onBack }) {
                 </Button>
                 <Button
                   variant="hero"
-                  size="lg"
                   onClick={() => setMode('facts')}
                   className="w-[500px] h-[100px] p-[50px] text-5xl flex items-center justify-center"
                 >


### PR DESCRIPTION
## Summary
- remove `size="lg"` from hero buttons so that custom `text-5xl` style takes effect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d67cf648832084684f277e75f2ba