### PR TITLE
Implement Fun Facts reading feature

### DIFF
--- a/frontend/src/AudioRecorder.jsx
+++ b/frontend/src/AudioRecorder.jsx
@@ -4,7 +4,14 @@ import { Mic, MicOff } from 'lucide-react';
 import { Button } from './components/ui/button';
 import axios from 'axios';
 
-export default function AudioRecorder({ threadId, passageText, afterSubmit, className }) {
+export default function AudioRecorder({
+  threadId,
+  passageText,
+  afterSubmit,
+  className,
+  startLabel = 'Start Reading',
+  stopLabel = 'Stop Recording'
+}) {
   const [recorder, setRecorder] = useState(null);
   const [isRecording, setIsRecording] = useState(false);
 
@@ -57,7 +64,7 @@ export default function AudioRecorder({ threadId, passageText, afterSubmit, clas
             className="min-w-[140px] shadow-glow-orange"
           >
             <Mic size={24} className="mr-2" />
-            Start Reading
+            {startLabel}
           </Button>
         </motion.div>
       ) : (
@@ -74,7 +81,7 @@ export default function AudioRecorder({ threadId, passageText, afterSubmit, clas
             className="min-w-[140px] bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700"
           >
             <MicOff size={24} className="mr-2" />
-            Stop Recording
+            {stopLabel}
           </Button>
         </motion.div>
       )}

--- a/frontend/src/pages/FunFacts.jsx
+++ b/frontend/src/pages/FunFacts.jsx
@@ -1,7 +1,49 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '../components/ui/button';
+import AudioRecorder from '../AudioRecorder';
+import { incrementCount } from '../utils/funFactsHistory';
 
 export default function FunFacts({ onBack }) {
+  const [options, setOptions] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [summary, setSummary] = useState('');
+  const [results, setResults] = useState(null);
+
+  useEffect(() => {
+    async function loadOpts() {
+      try {
+        const { data } = await axios.get('/api/fun_facts_options');
+        setOptions(data.options);
+      } catch (e) {
+        console.error('Failed to load options', e);
+      }
+    }
+    loadOpts();
+  }, []);
+
+  const chooseOption = async (opt) => {
+    const count = incrementCount(opt);
+    setSelected(opt);
+    try {
+      const { data } = await axios.post('/api/fun_facts_summary', { topic: opt, count });
+      setSummary(data.summary);
+    } catch (e) {
+      console.error('Failed to fetch summary', e);
+      setSummary(
+        `You are an inspiring educator teaching a 9 year old all about ${opt}. This is the ${count} time this topic has been introduced to the student so cater your response and level of detail/depth to this. Provide a detailed summary about this topic that is both educational and interesting.`
+      );
+    }
+  };
+
+  const handleAudioDone = (data) => {
+    if (data) {
+      const accuracy = data.words_total ? Math.round((data.words_correct / data.words_total) * 100) : 0;
+      setResults({ wpm: data.words_per_minute, accuracy });
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-center space-x-3">
@@ -10,7 +52,39 @@ export default function FunFacts({ onBack }) {
         </Button>
         <h1 className="text-2xl font-bold">Fun Facts</h1>
       </div>
-      <p className="text-lg text-slate-700">This section will contain interesting facts to explore. Stay tuned!</p>
+
+      {!selected && options && (
+        <div className="space-y-3">
+          {Object.values(options).map((opt) => (
+            <Button key={opt} onClick={() => chooseOption(opt)} className="w-full">
+              {opt}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <div className="space-y-4">
+          <p className="whitespace-pre-line text-lg">{summary}</p>
+
+          {!results && (
+            <AudioRecorder
+              threadId={`fact-${selected}`}
+              passageText={summary}
+              afterSubmit={handleAudioDone}
+              startLabel="Start Recording"
+              stopLabel="Stop Recording"
+            />
+          )}
+
+          {results && (
+            <div>
+              <p className="text-sm">Speed: {results.wpm} WPM</p>
+              <p className="text-sm">Accuracy: {results.accuracy}%</p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/utils/funFactsHistory.js
+++ b/frontend/src/utils/funFactsHistory.js
@@ -1,0 +1,24 @@
+export function loadCounts() {
+  try {
+    const stored = localStorage.getItem('funFactsCounts');
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveCounts(counts) {
+  localStorage.setItem('funFactsCounts', JSON.stringify(counts));
+}
+
+export function incrementCount(topic) {
+  const counts = loadCounts();
+  counts[topic] = (counts[topic] || 0) + 1;
+  saveCounts(counts);
+  return counts[topic];
+}
+
+export function getCount(topic) {
+  const counts = loadCounts();
+  return counts[topic] || 0;
+}


### PR DESCRIPTION
## Summary
- add helper to track fun facts history via localStorage
- allow custom button labels for `AudioRecorder`
- implement FunFacts page with topic selection, summary, and read-aloud scoring
- provide backend endpoints to serve random topics and build summaries
- fix data path for fun facts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a36100cd883209aabe1d0608b337a